### PR TITLE
Add filterByExpr to keep_abundant help

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -2782,7 +2782,7 @@ setMethod("keep_variable",
 #' @param .sample The name of the sample column
 #' @param .transcript The name of the transcript/gene column
 #' @param .abundance The name of the transcript/gene abundance column
-#' @param factor_of_interest The name of the column of the factor of interest. This is used for defining sample groups for the filtering process.
+#' @param factor_of_interest The name of the column of the factor of interest. This is used for defining sample groups for the filtering process. It uses the filterByExpr function from edgeR.
 #' @param minimum_counts A real positive number. It is the threshold of count per million that is used to filter transcripts/genes out from the scaling procedure.
 #' @param minimum_proportion A real positive number between 0 and 1. It is the threshold of proportion of samples for each transcripts/genes that have to be characterised by a cmp bigger than the threshold to be included for scaling procedure.
 #'

--- a/man/keep_abundant-methods.Rd
+++ b/man/keep_abundant-methods.Rd
@@ -79,7 +79,7 @@ keep_abundant(
 
 \item{.abundance}{The name of the transcript/gene abundance column}
 
-\item{factor_of_interest}{The name of the column of the factor of interest. This is used for defining sample groups for the filtering process.}
+\item{factor_of_interest}{The name of the column of the factor of interest. This is used for defining sample groups for the filtering process. It uses the filterByExpr function from edgeR.}
 
 \item{minimum_counts}{A real positive number. It is the threshold of count per million that is used to filter transcripts/genes out from the scaling procedure.}
 


### PR DESCRIPTION
I've added a little to the help for `keep_abundant` e.g. that `filterByExpr` is being used.

Noticed that there seems to be some repetition in the help, do you have to add the same info for all the different signatures or is there any way to reduce that?

<img width="654" alt="Screen Shot 2020-06-09 at 8 14 03 pm" src="https://user-images.githubusercontent.com/5591821/84136821-2a016080-aa8f-11ea-9914-49c213dea356.png">