### PR TITLE
export attributes

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -2387,7 +2387,7 @@ get_cell_type_proportions = function(.data,
 
 		# Attach attributes
 		reattach_internals(.data) %>%
-		memorise_methods_used("cibersort")
+		memorise_methods_used(tolower(method))
 
 
 }

--- a/R/methods.R
+++ b/R/methods.R
@@ -1530,7 +1530,7 @@ setGeneric("deconvolve_cellularity", function(.data,
 			dplyr::left_join(.data_processed,				by = quo_name(.sample)			) %>%
 
 			# Attach attributes
-			reattach_internals(.data)
+			reattach_internals(.data_processed)
 	}
 
 	else if (action == "get"){
@@ -1550,7 +1550,7 @@ setGeneric("deconvolve_cellularity", function(.data,
 			dplyr::left_join(.data_processed,				by = quo_name(.sample)			) %>%
 
 			# Attach attributes
-			reattach_internals(.data)
+			reattach_internals(.data_processed)
 	}
 
 	else if (action == "only") .data_processed

--- a/R/methods.R
+++ b/R/methods.R
@@ -3473,7 +3473,10 @@ setGeneric("get_bibliography", function(.data)
 {
 
 	# If there is not attributes parameter
-	if(!"methods_used" %in% (.data %>% attributes() %>% names()))
+	if(
+		!"internals" %in% (.data %>% attributes() %>% names()) &&
+		!"methods_used" %in% (.data %>% attr("internals") %>% names())
+	)
 		stop("tidybulk says: the attributes (attributes(...)) including the method tracking for for this object appear to be absent.")
 		
 	my_methods =

--- a/R/methods.R
+++ b/R/methods.R
@@ -3472,6 +3472,10 @@ setGeneric("get_bibliography", function(.data)
 .get_bibliography = 		function(.data)
 {
 
+	# If there is not attributes parameter
+	if(!"methods_used" %in% (.data %>% attributes() %>% names()))
+		stop("tidybulk says: the attributes (attributes(...)) including the method tracking for for this object appear to be absent.")
+		
 	my_methods =
 		.data %>%
 		attr("internals") %>%
@@ -3483,6 +3487,39 @@ setGeneric("get_bibliography", function(.data)
 		writeLines()
 
 }
+
+#' get_bibliography
+#' @inheritParams get_bibliography
+#'
+#' @docType methods
+#' @rdname get_bibliography-methods
+#'
+#' @return A `tbl` with additional columns for the statistics from the hypothesis test (e.g.,  log fold change, p-value and false discovery rate).
+setMethod("get_bibliography",
+					"tbl",
+					.get_bibliography)
+
+#' get_bibliography
+#' @inheritParams get_bibliography
+#'
+#' @docType methods
+#' @rdname get_bibliography-methods
+#'
+#' @return A `tbl` with additional columns for the statistics from the hypothesis test (e.g.,  log fold change, p-value and false discovery rate).
+setMethod("get_bibliography",
+					"tbl_df",
+					.get_bibliography)
+
+#' get_bibliography
+#' @inheritParams get_bibliography
+#'
+#' @docType methods
+#' @rdname get_bibliography-methods
+#'
+#' @return A `tbl` with additional columns for the statistics from the hypothesis test (e.g.,  log fold change, p-value and false discovery rate).
+setMethod("get_bibliography",
+					"spec_tbl_df",
+					.get_bibliography)
 
 #' get_bibliography
 #' @inheritParams get_bibliography

--- a/man/get_bibliography-methods.Rd
+++ b/man/get_bibliography-methods.Rd
@@ -3,10 +3,19 @@
 \docType{methods}
 \name{get_bibliography}
 \alias{get_bibliography}
+\alias{get_bibliography,tbl-method}
+\alias{get_bibliography,tbl_df-method}
+\alias{get_bibliography,spec_tbl_df-method}
 \alias{get_bibliography,tidybulk-method}
 \title{Produces the bibliography list of your workflow}
 \usage{
 get_bibliography(.data)
+
+\S4method{get_bibliography}{tbl}(.data)
+
+\S4method{get_bibliography}{tbl_df}(.data)
+
+\S4method{get_bibliography}{spec_tbl_df}(.data)
 
 \S4method{get_bibliography}{tidybulk}(.data)
 }
@@ -14,6 +23,12 @@ get_bibliography(.data)
 \item{.data}{A `tidybulk` tibble}
 }
 \value{
+A `tbl` with additional columns for the statistics from the hypothesis test (e.g.,  log fold change, p-value and false discovery rate).
+
+A `tbl` with additional columns for the statistics from the hypothesis test (e.g.,  log fold change, p-value and false discovery rate).
+
+A `tbl` with additional columns for the statistics from the hypothesis test (e.g.,  log fold change, p-value and false discovery rate).
+
 A `tbl` with additional columns for the statistics from the hypothesis test (e.g.,  log fold change, p-value and false discovery rate).
 }
 \description{


### PR DESCRIPTION
@mblue9 I have fixed the bibliography for deconvolution. Attrbuted were getting lost at the methods level.

Instead of putting add bibliography inside we can use `memorise_methods_used(tolower(method))` directly (as I did in this pull request)