### PR TITLE
Fix typo in DESeq raw result variable return

### DIFF
--- a/R/functions_SE.R
+++ b/R/functions_SE.R
@@ -1101,7 +1101,7 @@ get_differential_transcript_abundance_deseq2_SE <- function(.data,
 
 	# Return
 	list(
-		reslt_raw = deseq2_object,
+		result_raw = deseq2_object,
 		result =
 			# Read ft object
 			deseq2_object %>%


### PR DESCRIPTION
Fixes typo in reslt_raw variable name in DESeq section (referencing result_raw would give an error or blindly pull in value of result_raw generated by previous method).