### PR TITLE
fix a bug when .dim is set to more than 2 to compute tSNE and UMAP

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -2171,7 +2171,8 @@ get_reduced_dimensions_TSNE_bulk <-
 		do.call(Rtsne::Rtsne, c(list(df_tsne), arguments)) %$%
 			Y %>%
 			as_tibble(.name_repair = "minimal") %>%
-			setNames(c("tSNE1", "tSNE2")) %>%
+			setNames(paste0("tSNE", seq_len(ncol(.)))) %>%
+			#setNames(c("tSNE1", "tSNE2")) %>%
 
 			# add element name
 			dplyr::mutate(!!.element := df_tsne %>% rownames) %>%
@@ -2291,7 +2292,8 @@ get_reduced_dimensions_UMAP_bulk <-
 
     do.call(uwot::tumap, c(list(df_UMAP), arguments)) %>%
       as_tibble(.name_repair = "minimal") %>%
-      setNames(c("UMAP1", "UMAP2")) %>%
+      setNames(paste0("UMAP", seq_len(ncol(.)))) %>%
+      #setNames(c("UMAP1", "UMAP2"))
 
       # add element name
       dplyr::mutate(!!.element := df_UMAP %>% rownames) %>%

--- a/tests/testthat/test-bulk_dimsBUGfix_tSNE_UMAP.R
+++ b/tests/testthat/test-bulk_dimsBUGfix_tSNE_UMAP.R
@@ -1,0 +1,85 @@
+context('Fix the bug that can not calculate dimensions larger
+        than 2 with tSNE and UMAP')
+
+library(dplyr)
+data("breast_tcga_mini_SE")
+input_df_breast =   breast_tcga_mini_SE |> tidybulk() |> as_tibble() |> setNames(c( "b","a", "c", "c norm", "call"))
+
+
+test_that("Get reduced dimensions tSNE - no object",{
+
+  set.seed(132)
+
+  res =
+    input_df_breast |>
+    identify_abundant(a, b, c) |>
+
+    reduce_dimensions(
+      method="tSNE",
+      .abundance = c,
+      .element = a,
+      .feature = b,
+      action="get",
+      .dims = 3,
+      verbose=FALSE
+    ) |>
+    suppressMessages()
+
+  # DOES NOT REPRODUCE MAYBE BECAUSE OF DIFFERENT TSNE VERSIONS
+  # res |>
+  #   pull(tSNE1) |>
+  #   magrittr::extract2(1) |>
+  #   expect_equal(2.432608, tolerance = 0.01)
+
+  expect_equal(
+    typeof(res$`tSNE1`),
+    "double",
+    tolerance=1e-1
+  )
+
+  expect_true("tSNE3" %in% names(res))
+
+  expect_equal(
+    nrow(res),
+    251
+  )
+
+})
+
+test_that("Add reduced dimensions UMAP - no object",{
+
+  set.seed(132)
+
+  res =
+    input_df_breast |>
+    identify_abundant(a, b, c) |>
+
+    reduce_dimensions(
+      method="UMAP",
+      .abundance = c,
+      .element = a,
+      .feature = b,
+      action="add",
+      .dims = 3
+    )
+
+  expect_true("UMAP3" %in% names(res))
+
+  expect_false("UMAP4" %in% names(res))
+
+  res =
+    input_df_breast |>
+    identify_abundant(a, b, c) |>
+
+    reduce_dimensions(
+      method="UMAP",
+      .abundance = c,
+      .element = a,
+      .feature = b,
+      action="add",
+      .dims = 4
+    )
+
+  expect_true("UMAP4" %in% names(res))
+
+})


### PR DESCRIPTION
setNames(c("tSNE1", "tSNE2")) is changed to setNames(paste0("tSNE", seq_len(ncol(.))))

setNames(c("UMAP1", "UMAP2")) is changed to setNames(paste0("UMAP", seq_len(ncol(.))))