### PR TITLE
fix multiplier calcuation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidybulk
 Title: Brings transcriptomics to the tidyverse 
-Version: 1.19.3
+Version: 1.21.1
 Authors@R: c(person("Stefano", "Mangiola", email = "mangiolastefano@gmail.com",
                   role = c("aut", "cre")),
             person("Maria", "Doyle", email = "Maria.Doyle@petermac.org",

--- a/R/methods_SE.R
+++ b/R/methods_SE.R
@@ -161,11 +161,12 @@ setMethod("tidybulk", "RangedSummarizedExperiment", .tidybulk_se)
 
 	# Calculate multiplier
 	multiplier =
-		1 %>%
-		divide_by(library_size_filtered * nf) %>%
+		# Relecting the ratio of effective library size of the reference sample to the effective library size of each sample
+  		(library_size_filtered[reference] * nf[reference]) %>%
+  		divide_by(library_size_filtered * nf) 
 
 		# NOT HELPING - Put everything to the reference sample scale
-		multiply_by(library_size_filtered[reference])
+		# multiply_by(library_size_filtered[reference])
 
 		# At the moment no because would be different from TIBBLE behaviour
 		# %>%

--- a/tests/testthat/test-bulk_methods_SummarizedExperiment.R
+++ b/tests/testthat/test-bulk_methods_SummarizedExperiment.R
@@ -130,7 +130,7 @@ test_that("tidybulk SummarizedExperiment normalisation subset",{
 
   expect_equal(
     unique(SummarizedExperiment::colData(res)$multiplier),
-    c(1.3648110, 1.5756592, 1.1651309, 2.1282288, 1.2110911, 0.9574359, 1.4434610, 1.4897840),
+    c(1.425486, 1.645707, 1.216928, 2.222842, 1.264932, 1.000000, 1.507632, 1.556014),
     tolerance=1e-3
   )
 


### PR DESCRIPTION
Fix multiplier calculation for scale_abundance
New calculation relects the ratio of effective library size of the reference sample to the effective library size of each sample